### PR TITLE
Add Edit Feature to the Node Content Popup

### DIFF
--- a/src/features/editor/views/GraphView/stores/useGraph.ts
+++ b/src/features/editor/views/GraphView/stores/useGraph.ts
@@ -62,6 +62,7 @@ interface GraphActions {
   centerView: () => void;
   clearGraph: () => void;
   setZoomFactor: (zoomFactor: number) => void;
+  updateNodeContent: (path: string, newContent: any) => void;
 }
 
 const useGraph = create<Graph & GraphActions>((set, get) => ({
@@ -233,6 +234,16 @@ const useGraph = create<Graph & GraphActions>((set, get) => ({
   },
   toggleFullscreen: fullscreen => set({ fullscreen }),
   setViewPort: viewPort => set({ viewPort }),
+  updateNodeContent: (path: string, newContent: any) => set(state => {
+    return {
+      ...state,
+      nodes: state.nodes.map(node =>
+        node.path === path
+          ? { ...node, text: newContent }
+          : node
+      ),
+    };
+  }),
 }));
 
 export default useGraph;

--- a/src/features/modals/NodeModal/index.tsx
+++ b/src/features/modals/NodeModal/index.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import type { ModalProps } from "@mantine/core";
-import { Modal, Stack, Text, ScrollArea } from "@mantine/core";
+import { Modal, Stack, Text, ScrollArea, Group } from "@mantine/core";
 import { CodeHighlight } from "@mantine/code-highlight";
 import useGraph from "../../editor/views/GraphView/stores/useGraph";
+import useFile from "../../../store/useFile"; // Import your useFile store
 
 const dataToString = (data: any) => {
   const text = Array.isArray(data) ? Object.fromEntries(data) : data;
@@ -17,6 +18,46 @@ const dataToString = (data: any) => {
 export const NodeModal = ({ opened, onClose }: ModalProps) => {
   const nodeData = useGraph(state => dataToString(state.selectedNode?.text));
   const path = useGraph(state => state.selectedNode?.path || "");
+  const updateNodeContent = useGraph(state => state.updateNodeContent);
+  const setContents = useFile(state => state.setContents);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(nodeData ?? "");
+
+  React.useEffect(() => {
+    setEditValue(nodeData ?? "");
+  }, [nodeData, opened]);
+
+  const handleSave = () => {
+    if (!editValue || typeof editValue !== "string") {
+      alert("Content is empty or invalid.");
+      return;
+    }
+    try {
+      const parsedNode = JSON.parse(editValue);
+
+      // Get the full JSON from the text editor
+      const fullJson = JSON.parse(useFile.getState().getContents());
+
+      // Extract the correct key from the path
+      let key = path;
+      if (key.startsWith("{Root}.")) {
+        key = key.replace("{Root}.", "");
+      }
+
+      // Update only the relevant part using the node's key
+      if (key) {
+        fullJson[key] = parsedNode;
+      }
+
+      updateNodeContent(key, Object.entries(parsedNode));
+      setContents({ contents: JSON.stringify(fullJson, null, 2) });
+
+      setIsEditing(false);
+      setEditValue(dataToString(parsedNode));
+    } catch (e) {
+      alert("Invalid JSON format.");
+    }
+  };
 
   return (
     <Modal title="Node Content" size="auto" opened={opened} onClose={onClose} centered>
@@ -26,8 +67,26 @@ export const NodeModal = ({ opened, onClose }: ModalProps) => {
             Content
           </Text>
           <ScrollArea.Autosize mah={250} maw={600}>
-            <CodeHighlight code={nodeData} miw={350} maw={600} language="json" withCopyButton />
+            {isEditing ? (
+              <textarea
+                style={{ width: "100%", minHeight: 150 }}
+                value={editValue}
+                onChange={e => setEditValue(e.target.value)}
+              />
+            ) : (
+              <CodeHighlight code={nodeData} miw={350} maw={600} language="json" withCopyButton />
+            )}
           </ScrollArea.Autosize>
+          <Group gap="xs">
+            {isEditing ? (
+              <>
+                <button onClick={handleSave}>Save</button>
+                <button onClick={() => setIsEditing(false)}>Cancel</button>
+              </>
+            ) : (
+              <button onClick={() => setIsEditing(true)}>Edit</button>
+            )}
+          </Group>
         </Stack>
         <Text fz="xs" fw={500}>
           JSON Path


### PR DESCRIPTION
Added an "Edit" button to the node content modal, allowing users to edit node data directly. When saving changes in the modal, the text editor is updated with the modified node data, changing all views to reflect changes.