### PR TITLE
Attempt 2 | Continued The Functionality for Editing a Node and Saving its Changes.

### DIFF
--- a/src/features/modals/NodeModal/index.tsx
+++ b/src/features/modals/NodeModal/index.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import type { ModalProps } from "@mantine/core";
-// import { Modal, Stack, Text, ScrollArea } from "@mantine/core";
-import { Modal, Stack, Text, ScrollArea, Button} from "@mantine/core";
+import { Modal, Stack, Text, ScrollArea, Button, Group} from "@mantine/core";
 import Editor, { type EditorProps, loader, type OnMount, useMonaco } from "@monaco-editor/react";
-
+import { useState } from 'react';
+import useFile from "../../../store/useFile";
+import useConfig from "../../../store/useConfig";
+import styled from "styled-components";
+import type { NodeData } from "../../../types/graph";
 import { CodeHighlight } from "@mantine/code-highlight";
 import useGraph from "../../editor/views/GraphView/stores/useGraph";
 
@@ -17,40 +20,130 @@ const dataToString = (data: any) => {
   return JSON.stringify(text, replacer, 2);
 };
 
-/*
-TODO:
+const StyledEditorWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  user-select: none;
+`;
 
-Possible implementation 1:
-
-<ScrollArea.Autosize mah={250} maw={600}>
-  if the user does not want to edit then <CodeHighlight code={nodeData} miw={350} maw={600} language="json" withCopyButton />
-  if the user wants to edit then something else, maybe a similar thing to the live code editor??
-</ScrollArea.Autosize>
-*/
-
-/*
-Progress made in the hour:
-- Located (it seems) the files for the node functionality
-- Added an edit button in generally the same place as the example demonstration in the canvas video
-- Started implementation for the edit functionality when the user chooses to edit the node
-*/
+const StyledWrapper = styled.div`
+  display: grid;
+  height: 15vh;
+  grid-template-columns: 100%;
+  grid-template-rows: minmax(0, 1fr);
+`;
 
 export const NodeModal = ({ opened, onClose }: ModalProps) => {
-  const nodeData = useGraph(state => dataToString(state.selectedNode?.text));
+  const nodeData = useGraph(state => state.selectedNode?.text ? dataToString(state.selectedNode.text) : "");
   const path = useGraph(state => state.selectedNode?.path || "");
 
+  const updateNode = useGraph(state => state.setSelectedNode);
+  const updateFile = useFile(state => state.setContents);
+  const getContents = useFile(state => state.getContents)
+  const originalNode = useGraph.getState().selectedNode;
+  const fileContents = getContents();
+  const theme = useConfig(state => (state.darkmodeEnabled ? "vs-dark" : "light"));
+
+  const [isEditing, setEdit] = useState(false);
+  function handleEditClick() {
+    setOriginalNodeInfo(nodeData);
+    setCurrentNodeInfo(nodeData);
+    setEdit(!isEditing);
+  }
+
+  const [originalNodeInfo, setOriginalNodeInfo] = useState("");
+  const [currentNodeInfo, setCurrentNodeInfo] = useState("");
+  function changeCurrentNodeInfo(newData) {
+    setCurrentNodeInfo(newData ?? "");
+  }
+  
+  function handleClose() {
+    onClose();
+    setEdit(false);
+  }
+
+  function handleSaveClick() {
+    if (typeof(currentNodeInfo) === "string" && originalNodeInfo !== currentNodeInfo && currentNodeInfo.trim() !== "") {
+      updateNode({
+        ...originalNode,
+        text: JSON.parse(currentNodeInfo),} as NodeData);
+      
+      const fileContentsJSON = JSON.parse(fileContents);
+      const path = useGraph.getState().selectedNode?.path?.split(".") || [];
+      
+      let filePointer = fileContentsJSON;
+      filePointer[path[path.length - 1]] = useGraph.getState().selectedNode?.text;
+      updateFile({ contents: JSON.stringify(fileContentsJSON, null, 2) });
+    }
+
+    setEdit(false);
+  }
+
+  function nodeEditor(existingData) {
+    loader.config({
+      paths: {
+        vs: "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs",
+      },
+    });
+  
+    const editorOptions: EditorProps["options"] = {
+      formatOnPaste: true,
+      tabSize: 2,
+      formatOnType: true,
+      minimap: { enabled: false },
+      stickyScroll: { enabled: false },
+      scrollBeyondLastLine: false,
+      placeholder: existingData,
+      lineNumbers: "off",
+      lineDecorationsWidth: 0,
+      renderLineHighlight: "none",
+      bracketPairColorization: { enabled: false },
+      guides: { indentation: false },
+      overviewRulerBorder: false,
+      overviewRulerLanes: 0,
+      foldingHighlight: false,
+      matchBrackets: "never",
+    };
+
+    return (
+      <StyledEditorWrapper>
+        <StyledWrapper>
+          <Editor
+            height="100%"
+            theme={theme}
+            value={existingData}
+            options={editorOptions}
+            onChange={changeCurrentNodeInfo}
+          />
+        </StyledWrapper>
+      </StyledEditorWrapper>
+    );
+  }
+
   return (
-    <Modal title="Node Content" size="auto" opened={opened} onClose={onClose} centered>
+    <Modal title="Node Content" size="auto" opened={opened} onClose={handleClose} centered>
       <Stack py="sm" gap="sm">
         <Stack gap="xs">
           <Stack gap="xs" style={{ flexDirection: "row" }}>
             <Text fz="xs" fw={500}>
               Content
             </Text>
-            <Button size="xs" variant="light" style={{ marginLeft: "auto", marginTop: -8 }} onClick={() => alert("Button clicked!")}>Edit</Button>
+            {!isEditing ? (
+              <Button size="xs" variant="light" style={{ marginLeft: "auto", marginTop: -8 }} onClick={handleEditClick}>Edit</Button>
+            ) : (
+              <Group gap="xs" style={{ marginLeft: "auto" }}>
+                <Button size="xs" color="green" style={{ marginTop: -8 }} onClick={handleSaveClick}>Save</Button>
+                <Button size="xs" color="gray" style={{ marginTop: -8 }} onClick={handleEditClick}>Cancel</Button>
+              </Group>
+            )}
           </Stack>
           <ScrollArea.Autosize mah={250} maw={600}>
-            <Editor />
+            {!isEditing ? (
+              <CodeHighlight code={nodeData} miw={350} maw={600} language="json" withCopyButton />
+            ) : (
+              <>{nodeEditor(currentNodeInfo)}</>
+            )}
           </ScrollArea.Autosize>
         </Stack>
         <Text fz="xs" fw={500}>

--- a/src/features/modals/NodeModal/index.tsx
+++ b/src/features/modals/NodeModal/index.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import type { ModalProps } from "@mantine/core";
-import { Modal, Stack, Text, ScrollArea } from "@mantine/core";
+// import { Modal, Stack, Text, ScrollArea } from "@mantine/core";
+import { Modal, Stack, Text, ScrollArea, Button} from "@mantine/core";
+import Editor, { type EditorProps, loader, type OnMount, useMonaco } from "@monaco-editor/react";
+
 import { CodeHighlight } from "@mantine/code-highlight";
 import useGraph from "../../editor/views/GraphView/stores/useGraph";
 
@@ -14,6 +17,24 @@ const dataToString = (data: any) => {
   return JSON.stringify(text, replacer, 2);
 };
 
+/*
+TODO:
+
+Possible implementation 1:
+
+<ScrollArea.Autosize mah={250} maw={600}>
+  if the user does not want to edit then <CodeHighlight code={nodeData} miw={350} maw={600} language="json" withCopyButton />
+  if the user wants to edit then something else, maybe a similar thing to the live code editor??
+</ScrollArea.Autosize>
+*/
+
+/*
+Progress made in the hour:
+- Located (it seems) the files for the node functionality
+- Added an edit button in generally the same place as the example demonstration in the canvas video
+- Started implementation for the edit functionality when the user chooses to edit the node
+*/
+
 export const NodeModal = ({ opened, onClose }: ModalProps) => {
   const nodeData = useGraph(state => dataToString(state.selectedNode?.text));
   const path = useGraph(state => state.selectedNode?.path || "");
@@ -22,11 +43,14 @@ export const NodeModal = ({ opened, onClose }: ModalProps) => {
     <Modal title="Node Content" size="auto" opened={opened} onClose={onClose} centered>
       <Stack py="sm" gap="sm">
         <Stack gap="xs">
-          <Text fz="xs" fw={500}>
-            Content
-          </Text>
+          <Stack gap="xs" style={{ flexDirection: "row" }}>
+            <Text fz="xs" fw={500}>
+              Content
+            </Text>
+            <Button size="xs" variant="light" style={{ marginLeft: "auto", marginTop: -8 }} onClick={() => alert("Button clicked!")}>Edit</Button>
+          </Stack>
           <ScrollArea.Autosize mah={250} maw={600}>
-            <CodeHighlight code={nodeData} miw={350} maw={600} language="json" withCopyButton />
+            <Editor />
           </ScrollArea.Autosize>
         </Stack>
         <Text fz="xs" fw={500}>


### PR DESCRIPTION
## Additions and Changes
- Added Save and Cancel buttons that ideally allow the user to confirm or cancel the changes they make to a node.
- Changed the editor for the node to better fit what was shown in the Canvas lecture.
- Added implementation for tracking the changes made to a node, and, when specified, saving the changes to both the text editor code and the Graph or Tree visualization.

<img width="1915" height="814" alt="image" src="https://github.com/user-attachments/assets/8693047f-4138-4192-b5fa-bceeb0eaf6f3" />

<img width="1919" height="825" alt="image" src="https://github.com/user-attachments/assets/1f2dd202-c6c7-42b1-9cef-b9da756084b0" />

<img width="1918" height="821" alt="image" src="https://github.com/user-attachments/assets/b4b840b0-78e7-4774-9ab7-969876c8c9ac" />
